### PR TITLE
Bootstrap 5 Renderer

### DIFF
--- a/flask_nav3/__init__.py
+++ b/flask_nav3/__init__.py
@@ -101,6 +101,7 @@ class Nav(object):
     """The Flask-Nav extension.
 
     :param app: An optional :class:`~flask.Flask` app to initialize.
+    :param bootstrap: Use bootstrap 5 rendering. Default: False.
     """
 
     def __init__(self, app=None, bootstrap=False):
@@ -110,6 +111,7 @@ class Nav(object):
         ----------
         app : Flask, optional
             The Flask app, by default None
+        bootstrap: Use bootstrap 5 rendering. Default: False.
         """
         self.bootstrap = bootstrap
         self.elems = ElementRegistry()
@@ -130,6 +132,7 @@ class Nav(object):
         """Initialize an application.
 
         :param app: A :class:`~flask.Flask` app.
+        :param bootstrap: Use bootstrap 5 rendering. Default: False.
         """
         self.bootstrap = bootstrap
         if not hasattr(app, "extensions"):

--- a/flask_nav3/__init__.py
+++ b/flask_nav3/__init__.py
@@ -32,6 +32,8 @@ def get_renderer(app, iid):  # noqa: WPS210
     :param app: :class:`~flask.Flask` application to look ``iid`` up on
     :param iid: Internal renderer id-string to look up
     """
+    if iid is None and app.extensions["nav"].bootstrap:
+        iid = "bootstrap"
     renderer = app.extensions.get("nav_renderers", {})[iid]
 
     if isinstance(renderer, tuple):
@@ -101,7 +103,7 @@ class Nav(object):
     :param app: An optional :class:`~flask.Flask` app to initialize.
     """
 
-    def __init__(self, app=None):
+    def __init__(self, app=None, bootstrap=False):
         """Construct a Nav instance.
 
         Parameters
@@ -109,23 +111,27 @@ class Nav(object):
         app : Flask, optional
             The Flask app, by default None
         """
+        self.bootstrap = bootstrap
         self.elems = ElementRegistry()
 
         # per default, register the simple renderer
         simple = "{0}.renderers".format(__name__), "SimpleRenderer"
+        bootstrap = "{0}.renderers".format(__name__), "BootStrapRenderer"
         self._renderers = [
             ("simple", simple),
+            ("bootstrap", bootstrap),
             (None, simple, False),
         ]
 
         if app:
             self.init_app(app)
 
-    def init_app(self, app):
+    def init_app(self, app, bootstrap=False):
         """Initialize an application.
 
         :param app: A :class:`~flask.Flask` app.
         """
+        self.bootstrap = bootstrap
         if not hasattr(app, "extensions"):
             app.extensions = {}
 

--- a/flask_nav3/__init__.py
+++ b/flask_nav3/__init__.py
@@ -111,7 +111,8 @@ class Nav(object):
         ----------
         app : Flask, optional
             The Flask app, by default None
-        bootstrap: Use bootstrap 5 rendering. Default: False.
+        bootstrap: boolean
+            Use bootstrap 5 rendering. Default: False.
         """
         self.bootstrap = bootstrap
         self.elems = ElementRegistry()

--- a/flask_nav3/renderers.py
+++ b/flask_nav3/renderers.py
@@ -152,7 +152,7 @@ class BootStrapRenderer(Renderer):
         for item in node.items:
             group.add(tags.li(self.visit(item), _class="dropdown-item"))
 
-        return tags.div(title, group)
+        return tags.div(title, group, _class="dropdown")
 
     def visit_Separator(self, node):
         """Returns separator hrs."""

--- a/flask_nav3/renderers.py
+++ b/flask_nav3/renderers.py
@@ -29,6 +29,7 @@ class Renderer(Visitor):
             )
         return ""
 
+
 class SimpleRenderer(Renderer):
     """A very basic HTML5 renderer.
 
@@ -108,20 +109,20 @@ class BootStrapRenderer(Renderer):
 
     def visit_Link(self, node):
         """Returns arefs matching url."""
-        return tags.a(node.text, href=node.get_url(), _class='nav-link')
+        return tags.a(node.text, href=node.get_url(), _class="nav-link")
 
     def visit_Navbar(self, node):
         """Returns navbar classes."""
         kwargs = self.kwargs.copy()
 
-        _class = []
+        addclass = []
         if "class" in self.kwargs:
-            _class = kwargs['class'].split(" ")
+            addclass = kwargs["class"].split(" ")
 
-        kwargs['class'] = " ".join(_class + ["navbar", "navbar-expand-lg"])
+        kwargs["class"] = " ".join(addclass + ["navbar", "navbar-expand-lg"])
 
         cont = tags.nav(**kwargs)
-        ul = cont.add(tags.ul(_class=" ".join(_class + ["nav"])))
+        ul = cont.add(tags.ul(_class=" ".join(addclass + ["nav"])))
 
         for item in node.items:
             ul.add(tags.li(self.visit(item), _class="nav-item"))
@@ -130,7 +131,7 @@ class BootStrapRenderer(Renderer):
 
     def visit_View(self, node):
         """Returns arefs."""
-        kwargs = {"class": 'nav-link'}
+        kwargs = {"class": "nav-link"}
         if node.active:
             kwargs["_class"] = "nav-link active"
         return tags.a(
@@ -144,7 +145,12 @@ class BootStrapRenderer(Renderer):
         """Returns subgroup divs."""
         group = tags.ul(_class="dropdown-menu")
         kwargs = {"data-bs-toggle": "dropdown"}
-        title = tags.a(node.title, href="#", _class='nav-link dropdown-toggle', **kwargs)
+        title = tags.a(
+            node.title,
+            href="#",
+            _class="nav-link dropdown-toggle",
+            **kwargs,
+        )
 
         if node.active:
             title.attributes["class"] = "nav-link dropdown-toggle active"

--- a/flask_nav3/renderers.py
+++ b/flask_nav3/renderers.py
@@ -147,7 +147,7 @@ class BootStrapRenderer(Renderer):
         title = tags.a(node.title, href="#", _class='nav-link dropdown-toggle', **kwargs)
 
         if node.active:
-            title.attributes["class"] = "active"
+            title.attributes["class"] = "nav-link dropdown-toggle active"
 
         for item in node.items:
             group.add(tags.li(self.visit(item), _class="dropdown-item"))


### PR DESCRIPTION
This PR adds a new `BootStrapRenderer` which provides the necessary render functions to work with Bootstrap 5. 

This is tested using the `bootstrap_flask` python package. 

When initializing nav, you pass a `bootstrap=True` to the init. 

```
nav = Nav()
nav.init_app(app, bootstrap=True)
```
